### PR TITLE
Elm v0.15: exposing and centering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-build
-cache
+/elm-stuff/

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE HTML>
+<html>
+
+  <head>
+    <meta charset="utf-8" />
+    <title>vessel</title>
+  </head>
+
+  <body>
+    <script type="text/javascript" src="elm.js"></script>
+    <script type="text/javascript">Elm.fullscreen(Elm.Main)</script>
+  </body>
+</html>

--- a/vessel.elm
+++ b/vessel.elm
@@ -1,14 +1,15 @@
 import Keyboard
 import Window
 import Text
-import Text (centered, monospace, fromString)
+import Text exposing (monospace, fromString)
+import Graphics.Element exposing (centered)
 import Signal
-import Signal ((<~), (~), sampleOn, foldp)
-import Time (Time, fps, inSeconds)
-import List (length, foldl, filter, map, concatMap, any, (::))
-import Graphics.Element (image, container, middle, Element)
-import Graphics.Collage (collage, rect, ngon, filled, move, rotate, toForm)
-import Color (lightRed, white, darkRed)
+import Signal exposing ((<~), (~), sampleOn, foldp)
+import Time exposing (Time, fps, inSeconds)
+import List exposing (length, foldl, filter, map, concatMap, any, (::))
+import Graphics.Element exposing (image, container, middle, Element)
+import Graphics.Collage exposing (collage, rect, ngon, filled, move, rotate, toForm)
+import Color exposing (lightRed, white, darkRed)
 
 -- Important game properties
 shipStartY = -200


### PR DESCRIPTION
Elm added `exposing` to `import x (..)` syntax : `import x exposing (..)`
`Text.centered` was moved to `Graphics.Element.centered`
